### PR TITLE
Column name change for output file AllCounts.tsv

### DIFF
--- a/cb_sniffer.py
+++ b/cb_sniffer.py
@@ -368,7 +368,7 @@ if __name__ == '__main__':
 			open(outfile + '_counts_UB.tsv', 'w+') as UB, \
 			open(variants, 'r') as regions:
 		# write headers
-		var_header = ['chr', 'start', 'end', 'ref', 'alt', 'gene', 'type',
+		var_header = ['chr', 'start', 'end', 'ref', 'alt', 'type', 'gene',
 					  'UB_DEPTH', 'UB_ALT', 'UB_VAF', 'CB_barcodes', 'CB:UB_barcodes']
 		var_h = '\t'.join(var_header) + '\n'
 		var.write(var_h)


### PR DESCRIPTION
A minor issue, noticed the column name of 'type' and 'gene' is in the wrong order